### PR TITLE
カードへのメモ表示と開発ステータスドキュメント更新

### DIFF
--- a/app/views/deck/_card_content.html.erb
+++ b/app/views/deck/_card_content.html.erb
@@ -5,8 +5,11 @@
   <% end %>
 </div>
 
-<div class="flex-1 flex items-center justify-center">
+<div class="flex-1 flex flex-col items-center justify-center gap-2">
   <h2 class="text-xl font-bold text-gray-800 text-center"><%= @card.title %></h2>
+  <% if @card.memo.present? %>
+    <p class="text-sm text-gray-500 text-center whitespace-pre-wrap"><%= @card.memo %></p>
+  <% end %>
 </div>
 
 <div class="flex items-center justify-between mt-4">

--- a/doc/plan/phase2.md
+++ b/doc/plan/phase2.md
@@ -44,10 +44,9 @@
   - スワイプ方向に応じたアニメーション（カードがスライドアウト → 次カードが表示）
 - 候補0件: 空状態UIを表示
 
-## 2-6. カードアクション + スワイプアクション + トースト通知
+## 2-6. カードアクション + スワイプアクション + トースト通知 [DONE]
 
 - **上スワイプ → pin_now / 下スワイプ → snooze（プリセット選択へ）**
-- **カードタップ → 詳細画面へ遷移**
 - **pin_now**:
   - `user.now_item_id = item.id` に更新
   - Nowが既にある場合 → Phase 3（入れ替えダイアログ）で対応。Phase 2では単純に上書き
@@ -55,20 +54,14 @@
 - **snooze**:
   - スワイプ後にプリセット選択UI表示（明日 / 週末 / 来週）
   - `status = :snoozed`, `snooze_until` を設定
-  - Now中のItemの場合: `user.now_item_id = null`
   - トースト:「○○までスヌーズしました」
 - **done**:
   - ボタン操作（カード上に完了ボタン配置）
   - `status = :done`
-  - Now中のItemの場合: `user.now_item_id = null`
   - トースト:「完了しました」
 - アクション実行後: 次のカードを表示（リストから除去して次へ）
 - トースト: Stimulus controllerで一定時間後に自動消去
 
-## 2-7. カードタップ → 詳細画面遷移 + Now除外の適用
+## 2-7. Now除外の適用 [DONE]
 
-- **カードタップ → 詳細画面へ遷移**
-  - タップ検出（swipe_controller でドラッグ量が小さい場合をタップとみなす）
-  - 遷移先の詳細画面は別途設計
-- **Now除外の適用**（2-4 の未実装分）
-  - `DeckController#index` で `Items::DeckFilter.new(..., exclude_id: current_user.now_item_id)` を渡す
+- `DeckController#index` で `Items::DeckFilter.new(..., exclude_id: current_user.now_item_id)` を渡す

--- a/doc/plan/phase3.md
+++ b/doc/plan/phase3.md
@@ -6,18 +6,19 @@
 - 表示条件: `current_user.now_item_id` が存在する場合のみ表示
 - 表示内容: title / action_type / time_bucket
 - ボタン:
-  - `open`（開く）: 詳細画面へ遷移
   - `unpin`（外す）: `PinsController#destroy`
-  - `done`（完了）: `ItemStatusesController#update`（status: done）
+  - `done`（完了）: `CompletionsController#create`（status: done）
 - 実装: Turbo Frameで独立させ、アクション後に差し替え
 
-## 3-2. unpin（外す）
+## 3-2. unpin（外す）と now_item_id のクリア
 
 - `PinsController#destroy`
   - `current_user.update!(now_item_id: nil)`
   - Itemの `status` は変更しない（activeのまま候補に戻る）
   - トースト:「Nowを外しました」
   - Deck画面の場合: シャッフルリストを再生成（外したItemが候補に戻るため）
+- snooze / done 実行時に Now中のItemだった場合も `now_item_id = nil` にする
+  - `SnoozeController#create`, `CompletionsController#create` で対応
 
 ## 3-3. Now入れ替えダイアログ（replace / cancel）
 


### PR DESCRIPTION
## Summary

- カードにメモ（`memo` カラム）を表示するよう `_card_content.html.erb` を更新
- phase2.md: 詳細画面不要の方針を反映し、2-6 を [DONE] に更新
- phase3.md: snooze/done 実行時の `now_item_id` クリアを 3-2 に集約