### PR TITLE
Implement item creation functionality with form and routing updates

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,23 @@ class ItemsController < ApplicationController
   def index
     @items = current_user.items
   end
+
+  def new
+    @item = current_user.items.build
+  end
+
+  def create
+    @item = current_user.items.build(item_params)
+    if @item.save
+      redirect_to deck_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:title, :url, :memo, :action_type, :time_bucket, :energy)
+  end
 end

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,0 +1,84 @@
+<%= form_with model: item, class: 'flex flex-col gap-6' do |f| %>
+  <%# Title %>
+  <div>
+    <%= f.label :title, 'Title', class: 'block text-sm font-medium text-gray-700 mb-1' %>
+    <%= f.text_field :title,
+          placeholder: 'e.g. Read this article',
+          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400' %>
+    <% if item.errors[:title].any? %>
+      <p class="mt-1 text-xs text-red-500"><%= item.errors[:title].first %></p>
+    <% end %>
+  </div>
+
+  <%# URL %>
+  <div>
+    <%= f.label :url, 'URL', class: 'block text-sm font-medium text-gray-700 mb-1' %>
+    <%= f.url_field :url,
+          placeholder: 'https://...',
+          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400' %>
+  </div>
+
+  <%# Memo %>
+  <div>
+    <%= f.label :memo, 'Memo', class: 'block text-sm font-medium text-gray-700 mb-1' %>
+    <%= f.text_area :memo,
+          rows: 3,
+          placeholder: 'Notes...',
+          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 resize-none' %>
+  </div>
+
+  <%# Action Type %>
+  <div>
+    <p class="text-sm font-medium text-gray-700 mb-2">Action</p>
+    <div class="flex flex-wrap gap-2">
+      <% Item.action_types.each_key do |type| %>
+        <label class="cursor-pointer">
+          <%= f.radio_button :action_type, type, class: 'sr-only peer' %>
+          <span class="px-3 py-1 rounded-full border border-gray-300 text-sm text-gray-600
+                       peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600
+                       transition">
+            <%= t("enums.item.action_type.#{type}") %>
+          </span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Time Bucket %>
+  <div>
+    <p class="text-sm font-medium text-gray-700 mb-2">Time</p>
+    <div class="flex flex-wrap gap-2">
+      <% Item.time_buckets.each_key do |bucket| %>
+        <label class="cursor-pointer">
+          <%= f.radio_button :time_bucket, bucket, class: 'sr-only peer' %>
+          <span class="px-3 py-1 rounded-full border border-gray-300 text-sm text-gray-600
+                       peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600
+                       transition">
+            <%= t("enums.item.time_bucket.#{bucket}") %>
+          </span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Energy %>
+  <div>
+    <p class="text-sm font-medium text-gray-700 mb-2">Energy</p>
+    <div class="flex flex-wrap gap-2">
+      <% Item.energies.each_key do |level| %>
+        <label class="cursor-pointer">
+          <%= f.radio_button :energy, level, class: 'sr-only peer' %>
+          <span class="px-3 py-1 rounded-full border border-gray-300 text-sm text-gray-600
+                       peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600
+                       transition">
+            <%= t("enums.item.energy.#{level}") %>
+          </span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <%= f.submit 'Add Item',
+        class: 'w-full py-3 bg-indigo-600 text-white rounded-xl font-semibold text-sm
+                hover:bg-indigo-700 active:bg-indigo-800 transition cursor-pointer' %>
+<% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-md mx-auto px-4 pt-6 pb-24">
+  <h1 class="text-xl font-bold text-gray-800 mb-6">Add Item</h1>
+  <%= render 'form', item: @item %>
+</div>

--- a/app/views/shared/_tab_bar.html.erb
+++ b/app/views/shared/_tab_bar.html.erb
@@ -7,7 +7,7 @@
       <span class="text-[10px] font-medium">Deck</span>
     <% end %>
 
-    <%= link_to items_path, class: "flex flex-col items-center justify-center w-16 py-1 transition #{tab_active?('items') ? 'text-indigo-600' : 'text-gray-400'}" do %>
+    <%= link_to new_item_path, class: "flex flex-col items-center justify-center w-16 py-1 transition #{tab_active?('items') ? 'text-indigo-600' : 'text-gray-400'}" do %>
       <div class="flex items-center justify-center w-10 h-10 rounded-full bg-indigo-600 -mt-5 shadow-md">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     resources :snoozes, only: [:create]
     resources :completions, only: [:create]
   end
-  resources :items, only: [:index]
+  resources :items, only: [:index, :new, :create]
 
   # Authentication
   get '/login', to: 'sessions#new', as: :login

--- a/doc/plan/phase3.md
+++ b/doc/plan/phase3.md
@@ -1,6 +1,6 @@
 # Phase 3: Now（いまやる）
 
-## 3-1. Now固定ヘッダー（Deck上部）
+## 3-1. Now固定ヘッダー（Deck上部） [Done]
 
 - `DeckController#index` のビューに Now固定ヘッダーを追加
 - 表示条件: `current_user.now_item_id` が存在する場合のみ表示
@@ -10,7 +10,7 @@
   - `done`（完了）: `CompletionsController#create`（status: done）
 - 実装: Turbo Frameで独立させ、アクション後に差し替え
 
-## 3-2. unpin（外す）と now_item_id のクリア
+## 3-2. unpin（外す）と now_item_id のクリア [Done]
 
 - `PinsController#destroy`
   - `current_user.update!(now_item_id: nil)`
@@ -19,17 +19,3 @@
   - Deck画面の場合: シャッフルリストを再生成（外したItemが候補に戻るため）
 - snooze / done 実行時に Now中のItemだった場合も `now_item_id = nil` にする
   - `SnoozeController#create`, `CompletionsController#create` で対応
-
-## 3-3. Now入れ替えダイアログ（replace / cancel）
-
-- Phase 2の `pin_now` を修正: Nowが既にある場合はダイアログを表示
-- ダイアログ表示: Turbo Stream or モーダル（Stimulus controllerで制御）
-- 選択肢:
-  - `replace`（入れ替える）
-    - `current_user.update!(now_item_id: new_item.id)`
-    - 旧Nowの `status` は変更しない（activeのまま候補に戻る）
-    - トースト:「Nowを入れ替えました」
-  - `cancel`（キャンセル）
-    - ダイアログを閉じるだけ
-- ルーティング: `PinsController#create`（replace時も同じアクション、既存Now有無でダイアログ表示を分岐）
-


### PR DESCRIPTION
## 概要

アイテム追加機能を実装。タブバーの「+」ボタンから新規アイテム作成フォームへ遷移できるようにした。

## 変更内容

- `ItemsController` に `new` / `create` アクションを追加
- アイテム作成フォーム（`_form` partial）を実装
  - Title, URL, Memo の入力フィールド
  - Action / Time / Energy を pill ボタンで選択
- タブバーの「+」リンク先を `items_path` → `new_item_path` に変更
- ルーティングに `new`, `create` を追加