### PR TITLE
feat: add URL paste detection to auto-fill title field

### DIFF
--- a/app/javascript/controllers/snooze_preset_controller.js
+++ b/app/javascript/controllers/snooze_preset_controller.js
@@ -4,7 +4,7 @@ import { slideOutVertical } from 'helpers/card_animation';
 export default class extends Controller {
   snooze(event) {
     this.element.classList.add('hidden');
-    slideOutVertical(this._cardElement(), 1);
+    slideOutVertical(this.#cardElement(), 1);
   }
 
   cancel(event) {
@@ -12,7 +12,7 @@ export default class extends Controller {
     this.element.classList.add('hidden');
   }
 
-  _cardElement() {
+  #cardElement() {
     return this.element.closest('[data-controller="swipe"]');
   }
 }

--- a/app/javascript/controllers/swipe_controller.js
+++ b/app/javascript/controllers/swipe_controller.js
@@ -17,13 +17,13 @@ export default class extends Controller {
     this.threshold = 80;
 
     const el = this.element;
-    el.addEventListener('pointerdown', this._onPointerDown.bind(this));
-    el.addEventListener('pointermove', this._onPointerMove.bind(this));
-    el.addEventListener('pointerup', this._onPointerUp.bind(this));
-    el.addEventListener('pointercancel', this._onPointerUp.bind(this));
+    el.addEventListener('pointerdown', this.#onPointerDown.bind(this));
+    el.addEventListener('pointermove', this.#onPointerMove.bind(this));
+    el.addEventListener('pointerup', this.#onPointerUp.bind(this));
+    el.addEventListener('pointercancel', this.#onPointerUp.bind(this));
   }
 
-  _onPointerDown(e) {
+  #onPointerDown(e) {
     this.element.setPointerCapture(e.pointerId);
     this.startX = e.clientX;
     this.startY = e.clientY;
@@ -33,7 +33,7 @@ export default class extends Controller {
     this.element.style.transition = 'none';
   }
 
-  _onPointerMove(e) {
+  #onPointerMove(e) {
     if (!this.dragging) return;
     e.preventDefault();
 
@@ -66,7 +66,7 @@ export default class extends Controller {
     }
   }
 
-  _onPointerUp() {
+  #onPointerUp() {
     if (!this.dragging) return;
     this.dragging = false;
 
@@ -99,18 +99,18 @@ export default class extends Controller {
 
     // 下スワイプ（スヌーズプリセット表示）
     if (absY > absX && absY > this.threshold && this.currentY > 0) {
-      this._resetLabels();
+      this.#resetLabels();
       snapBack(this.element);
       const preset = this.element.querySelector('[data-controller="snooze-preset"]');
       if (preset) preset.classList.remove('hidden');
       return;
     }
 
-    this._resetLabels();
+    this.#resetLabels();
     snapBack(this.element);
   }
 
-  _resetLabels() {
+  #resetLabels() {
     if (this.hasUpLabelTarget) this.upLabelTarget.style.opacity = 0;
     if (this.hasDownLabelTarget) this.downLabelTarget.style.opacity = 0;
   }

--- a/app/javascript/controllers/url_title_controller.js
+++ b/app/javascript/controllers/url_title_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['url', 'title']
+
+  paste(event) {
+    const pasted = (event.clipboardData || window.clipboardData).getData('text')
+    if (!this.#isUrl(pasted)) return
+
+    // pasteイベント時点ではまだ値が反映されていないため非同期で処理
+    setTimeout(() => this.#fetchTitle(pasted), 0)
+  }
+
+  #isUrl(value) {
+    try {
+      const url = new URL(value)
+      return url.protocol === 'http:' || url.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }
+
+  async #fetchTitle(url) {
+    try {
+      const res = await fetch(`/title?url=${encodeURIComponent(url)}`)
+      if (!res.ok) return
+
+      const { title } = await res.json()
+      if (title && this.titleTarget.value === '') {
+        this.titleTarget.value = title
+      }
+    } catch {
+      // 取得失敗時は何もしない
+    }
+  }
+}

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,10 +1,11 @@
-<%= form_with model: item, class: 'flex flex-col gap-6' do |f| %>
+<%= form_with model: item, class: 'flex flex-col gap-6', data: { controller: 'url-title' } do |f| %>
   <%# Title %>
   <div>
     <%= f.label :title, 'Title', class: 'block text-sm font-medium text-gray-700 mb-1' %>
     <%= f.text_field :title,
           placeholder: 'e.g. Read this article',
-          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400' %>
+          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400',
+          data: { url_title_target: 'title' } %>
     <% if item.errors[:title].any? %>
       <p class="mt-1 text-xs text-red-500"><%= item.errors[:title].first %></p>
     <% end %>
@@ -15,7 +16,8 @@
     <%= f.label :url, 'URL', class: 'block text-sm font-medium text-gray-700 mb-1' %>
     <%= f.url_field :url,
           placeholder: 'https://...',
-          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400' %>
+          class: 'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400',
+          data: { url_title_target: 'url', action: 'paste->url-title#paste' } %>
   </div>
 
   <%# Memo %>


### PR DESCRIPTION
## Summary

- URLフィールドへのペーストを検知し、`TitlesController` にリクエストしてtitleを自動入力するStimulusコントローラーを追加
- 既存コントローラーのプライベートメソッドを `_` プレフィックスから `#` 構文に統一

## Test plan

- [ ] アイテム追加フォームのURLフィールドにURLをペーストするとtitleが自動入力される
- [ ] titleフィールドに既に値がある場合は上書きされない
- [ ] 無効なURL・非URL文字列をペーストしてもエラーにならない
- [ ] title取得失敗時（タイムアウト等）はtitleフィールドが空のまま