### PR TITLE
test: items_spec を整理・拡充し phase5 ドキュメントを更新

### DIFF
--- a/doc/plan/phase5.md
+++ b/doc/plan/phase5.md
@@ -15,12 +15,17 @@
 - 開閉状態の保存はしない（画面遷移やリロードで閉じた状態に戻る）
 - 展開時の表示項目: title / url（リンク）/ memo / action_type / time_bucket / energy / status / created_at
 
-## 5-3. アイテムの更新
+## 5-3. URLペースト時のローディング表示
+
+- URLフィールドにURLをペーストしてタイトル取得中、タイトルフィールド付近にローディング表示（例: 「タイトルを取得中...」）
+- 取得完了（成功・失敗問わず）で非表示にする
+
+## 5-4. アイテムの更新
 
 - `ItemsController#edit` / `#update`: 編集フォーム
   - 編集可能: title / url / memo / action_type / time_bucket / energy
 
-## 5-4. アーカイブ
+## 5-5. アーカイブ
 
 - `ArchivesController#create`（archiveの唯一の導線）
 - `status` が `active` または `snoozed` の場合のみ表示（`done` のItemには出さない）
@@ -29,7 +34,7 @@
 - トースト:「アーカイブしました」
 - 実行後: Items画面へリダイレクト
 
-## 5-5. PWAマニフェスト（ホーム画面追加のみ）
+## 5-6. PWAマニフェスト（ホーム画面追加のみ）
 
 - `public/manifest.json` を作成
   - `name` / `short_name` / `icons` / `start_url` / `display: standalone` / `theme_color`

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -9,29 +9,81 @@ RSpec.describe 'Items画面', type: :system do
   end
 
   describe '一覧' do
-    let!(:active_item)  { create(:item, user: user, status: :active) }
-    let!(:snoozed_item) { create(:item, user: user, status: :snoozed) }
+    let!(:active_item)   { create(:item, user: user, status: :active) }
+    let!(:snoozed_item)  { create(:item, user: user, status: :snoozed) }
+    let!(:done_item)     { create(:item, user: user, status: :done) }
+    let!(:archived_item) { create(:item, user: user, status: :archived) }
 
     before { visit items_path }
 
     context 'デフォルト（status未指定）' do
-      it 'activeアイテムが表示される' do
+      it 'activeアイテムのみ表示される' do
         expect(page).to have_content(active_item.title)
         expect(page).not_to have_content(snoozed_item.title)
+        expect(page).not_to have_content(done_item.title)
+        expect(page).not_to have_content(archived_item.title)
+      end
+
+      it '1件表示される' do
+        expect(page).to have_css('.bg-white.rounded-xl', count: 1)
       end
     end
 
-    context 'タブ切り替え' do
-      it 'あとでタブをクリックするとsnoozedアイテムが表示される' do
-        click_link 'あとで'
+    context 'あとでタブ' do
+      before { click_link 'あとで' }
+
+      it 'snoozedアイテムのみ表示される' do
         expect(page).to have_content(snoozed_item.title)
         expect(page).not_to have_content(active_item.title)
       end
+
+      it '1件表示される' do
+        expect(page).to have_css('.bg-white.rounded-xl', count: 1)
+      end
     end
 
-    context '空のタブ' do
-      it '完了タブは空メッセージを表示する' do
+    context '完了タブ' do
+      before { click_link '完了' }
+
+      it 'doneアイテムのみ表示される' do
+        expect(page).to have_content(done_item.title)
+        expect(page).not_to have_content(active_item.title)
+      end
+
+      it '1件表示される' do
+        expect(page).to have_css('.bg-white.rounded-xl', count: 1)
+      end
+    end
+
+    context 'アーカイブタブ' do
+      before { click_link 'アーカイブ' }
+
+      it 'archivedアイテムのみ表示される' do
+        expect(page).to have_content(archived_item.title)
+        expect(page).not_to have_content(active_item.title)
+      end
+
+      it '1件表示される' do
+        expect(page).to have_css('.bg-white.rounded-xl', count: 1)
+      end
+    end
+
+    context '空のタブ（該当アイテムなし）' do
+      let!(:active_item)   { nil }
+      let!(:snoozed_item)  { nil }
+      let!(:done_item)     { nil }
+      let!(:archived_item) { nil }
+
+      it '全タブで空メッセージが表示される' do
+        expect(page).to have_content('アイテムがありません')
+
+        click_link 'あとで'
+        expect(page).to have_content('アイテムがありません')
+
         click_link '完了'
+        expect(page).to have_content('アイテムがありません')
+
+        click_link 'アーカイブ'
         expect(page).to have_content('アイテムがありません')
       end
     end


### PR DESCRIPTION
## Summary

- items_spec の一覧テストに archived タブを追加
- 完了・アーカイブタブのコンテンツありテストを追加（空のみだったのを修正）
- 各タブに件数チェック（CSSセレクタで1件確認）を追加
- 空のタブテストを1つの `it` に統合し、全4タブをカバー
- phase5.md にURLペースト時ローディング表示の仕様（5-3）を追加

## Test plan

- [ ] `bundle exec rspec spec/system/items_spec.rb` がグリーンになること