### PR TITLE
feat: add PWA manifest and icon for home screen installation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,7 @@
 
     <%= yield :head %>
 
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <link rel="manifest" href="/manifest.json">
 
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">

--- a/public/icons/icon.svg
+++ b/public/icons/icon.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#72B4FF"/>
+      <stop offset="100%" stop-color="#3060D0"/>
+    </linearGradient>
+    <linearGradient id="pinHead" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFD55A"/>
+      <stop offset="100%" stop-color="#E89510"/>
+    </linearGradient>
+    <filter id="cs" x="-20%" y="-10%" width="140%" height="130%">
+      <feDropShadow dx="-2" dy="4" stdDeviation="6" flood-color="#1A3A80" flood-opacity="0.25"/>
+    </filter>
+    <filter id="ps" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="512" height="512" rx="100" fill="url(#bg)"/>
+
+  <!-- Sparkle (top-right) -->
+  <g opacity="0.75">
+    <line x1="395" y1="68" x2="395" y2="88" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="385" y1="78" x2="405" y2="78" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+  <g opacity="0.5">
+    <line x1="370" y1="55" x2="370" y2="67" stroke="white" stroke-width="2" stroke-linecap="round"/>
+    <line x1="364" y1="61" x2="376" y2="61" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  </g>
+
+  <!-- Card 3 (back, darkest blue) -->
+  <g transform="rotate(-20, 258, 162)" filter="url(#cs)">
+    <rect x="128" y="145" width="260" height="210" rx="18" fill="#4478E0"/>
+  </g>
+
+  <!-- Card 2 (medium blue) -->
+  <g transform="rotate(-10, 258, 162)" filter="url(#cs)">
+    <rect x="128" y="145" width="260" height="210" rx="18" fill="#7AACFF"/>
+  </g>
+
+  <!-- Card 1 (front, white, slight clockwise tilt) -->
+  <g transform="rotate(2, 258, 162)" filter="url(#cs)">
+    <rect x="128" y="145" width="260" height="210" rx="18" fill="white"/>
+  </g>
+
+  <!-- Push pin -->
+  <g filter="url(#ps)">
+    <!-- Pin stem -->
+    <rect x="253" y="170" width="10" height="28" rx="4" fill="#C07A10"/>
+    <!-- Pin head -->
+    <circle cx="258" cy="155" r="20" fill="url(#pinHead)"/>
+    <!-- Pin gloss -->
+    <ellipse cx="252" cy="148" rx="8" ry="6" fill="white" opacity="0.45"/>
+  </g>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Nextup",
+  "short_name": "Nextup",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#2060D8",
+  "background_color": "#2060D8",
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `public/manifest.json` を作成（name / start_url / display:standalone / theme_color / icons）
- SVGアイコン（`public/icons/icon.svg`）を追加 — 青背景・重ねカード・オレンジピンのデザイン
- `application.html.erb` に `<link rel="manifest">` を追加

## Test plan

- スマホブラウザで「ホーム画面に追加」が表示されること
- アイコンが正しく表示されること
- 追加後、スタンドアロンモード（アドレスバーなし）で起動すること