### PR TITLE
feat: configure Kamal deployment

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -2,19 +2,10 @@
 # and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
 
-# Example of extracting secrets from 1password (or another compatible pw manager)
-# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
-
-# Example of extracting secrets from Rails credentials
-# KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
-
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
-# KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-
 # Improve security by using a password manager. Never check config/master.key into git!
 RAILS_MASTER_KEY=$(cat config/master.key)
+
+# Load from .env.kamal
+KAMAL_REGISTRY_PASSWORD=$(grep KAMAL_REGISTRY_PASSWORD .env.kamal | cut -d'=' -f2)
+GOOGLE_CLIENT_ID=$(grep KAMAL_GOOGLE_CLIENT_ID .env.kamal | cut -d'=' -f2)
+GOOGLE_CLIENT_SECRET=$(grep KAMAL_GOOGLE_CLIENT_SECRET .env.kamal | cut -d'=' -f2)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,44 +2,35 @@
 service: nextup
 
 # Name of the container image (use your-user/app-name on external registries).
-image: nextup
+image: takahiromasui001/nextup
 
 # Deploy to these servers.
 servers:
   web:
-    - 192.168.0.1
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+    - nextup-deck.duckdns.org
 
-# Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
-# If used with Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
-#
-# Using an SSL proxy like this requires turning on config.assume_ssl and config.force_ssl in production.rb!
-#
-# Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
-#
-# proxy:
-#   ssl: true
-#   host: app.example.com
+# Enable SSL auto certification via Let's Encrypt.
+proxy:
+  ssl: true
+  host: nextup-deck.duckdns.org
 
 # Where you keep your container images.
 registry:
-  # Alternatives: hub.docker.com / registry.digitalocean.com / ghcr.io / ...
-  server: localhost:5555
+  server: ghcr.io
+  username: takahiromasui001
+  password:
+    - KAMAL_REGISTRY_PASSWORD
 
-  # Needed for authenticated registries.
-  # username: your-user
-
-  # Always use an access token rather than real password when possible.
-  # password:
-  #   - KAMAL_REGISTRY_PASSWORD
+# SSH settings
+ssh:
+  port: <%= `grep KAMAL_SSH_PORT .env.kamal | cut -d'=' -f2`.strip %>
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
   secret:
     - RAILS_MASTER_KEY
+    - GOOGLE_CLIENT_ID
+    - GOOGLE_CLIENT_SECRET
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
@@ -69,31 +60,19 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "nextup_storage:/rails/storage"
+  - 'nextup_storage:/rails/storage'
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 asset_path: /rails/public/assets
 
-
 # Configure the image builder.
 builder:
   arch: amd64
 
-  # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
-  # remote: ssh://docker@docker-builder-server
-  #
-  # # Pass arguments and secrets to the Docker build process
-  # args:
-  #   RUBY_VERSION: 3.3.0
-  # secrets:
-  #   - GITHUB_TOKEN
-  #   - RAILS_MASTER_KEY
-
-# Use a different ssh user than root
-# ssh:
-#   user: app
+  # Build image via remote server (useful for faster amd64 builds on arm64 computers)
+  remote: ssh://root@nextup-deck.duckdns.org:<%= `grep KAMAL_SSH_PORT .env.kamal | cut -d'=' -f2`.strip %>
 
 # Use accessory services (secrets come from .kamal/secrets).
 # accessories:


### PR DESCRIPTION
## Summary
- ghcr.io をレジストリとして設定し、SSL(Let's Encrypt)を有効化
- nextup-deck.duckdns.org へのデプロイ設定（SSH、リモートビルド含む）
- .kamal/secrets で .env.kamal から秘密情報を読み込むよう設定